### PR TITLE
update-failure-exception-1

### DIFF
--- a/assertion/src/main/kotlin/enforcers/FailureException.kt
+++ b/assertion/src/main/kotlin/enforcers/FailureException.kt
@@ -6,9 +6,9 @@ public class FailureException internal constructor(
     override fun toString(): com.s12works.tellAStory.objectRepresentation.Translation =
         com.s12works.tellAStory.objectRepresentation.getStandardRepr(this)
  
-    // potentially remaster to include auto-gen message as qualification   
     override fun equals(other: Any?): Boolean = (
         other is FailureException &&
-        this.report == other.report
+        this.report == other.report &&
+        this.message == other.message
     )
 }


### PR DESCRIPTION
https://github.com/s12works/chs-tell-a-story/blob/639fd5037633f1fe66909fd1e1a67bcbe9d31592/assertion/src/main/kotlin/enforcers/FailureException.kt#L12
This simply changes `FailureException.equals(Any?)` to include `message` as a valid qualification for assessing equality.